### PR TITLE
Insere liberação de assinaturas para pagamento via Boleto

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1168,6 +1168,8 @@ class VindiPaymentProcessor
         }
         if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();
+        } elseif (reset($bill['charges'])['payment_method']['code'] === 'bank_slip') {
+            $status = 'processing';
         } else {
             $status = 'pending';
         }


### PR DESCRIPTION
## O que mudou
Caso o método de pagamento seja Boleto bancário, a assinatura ficará ativa instantaneamente, e o plugin apenas atualizará as informações de pagamento quando ocorrerem.
Isso acontece para impedir que clientes sejam privados do acesso antes do pagamento do boleto.

## Motivação
Em clientes que utilizam o plugin "WooCommerce Memberships" (para controle de acesso), as assinaturas criadas via Boleto ficam pendentes até que o pagamento concluído.
Em alguns casos, o ideal é que a assinatura seja ativa desde o primeiro momento, pois a inadimplência é considerada apenas nas renovações.

## Solução proposta
Alterar o status padrão de criação dos pedidos via Boleto para "processando". Assim a assinatura iniciará imediatamente.
Quando ocorrer o pagamento do pedido, o mesmo será atualizado para o status definido na configuração do plugin Vindi.