### PR TITLE
Altera o status padrão de faturas relacionadas a renovação de período

### DIFF
--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -118,6 +118,14 @@ class VindiWebhooks
     update_post_meta($order->id, 'vindi_order', $order_post_meta);
     $this->vindi_settings->logger->log('Novo Período criado: Pedido #'.$order->id);
 
+    if ($this->vindi_settings->dependencies->is_wc_memberships_active()) {
+      $subscription->update_status(
+        'pending-cancel',
+        'O status da assinatura foi atualizado pela Vindi' .
+        'para evitar bloqueios de acesso em clientes relacionados ao plugin WooCommerce Memberships'
+      );
+    }
+
     // We've already processed the renewal
     remove_action( 'woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal' );
   }
@@ -186,6 +194,16 @@ class VindiWebhooks
     if ($vindi_order_info['bill']['status'] == 'paid') {
         $new_status = $this->vindi_settings->get_return_status();
         $order->update_status($new_status, __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI));
+
+        $wc_subscription = $this->find_subscription_by_id($data->bill->subscription->code);
+        if (!$wc_subscription->has_status('active')) {
+            $wc_subscription->update_status(
+              'active',
+              'Recebemos a informação que o pagamento foi realizado!' .
+              'A assinatura foi reativada pela Vindi.'
+            );
+        }
+
         $this->update_next_payment($data);
     }
   }

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -124,6 +124,7 @@ class VindiWebhooks
         'O status da assinatura foi atualizado pela Vindi' .
         'para evitar bloqueios de acesso em clientes relacionados ao plugin WooCommerce Memberships'
       );
+      $subscription->update_dates(array('end_date' => $this->format_date($renew_infos['bill_due_at'])));
     }
 
     // We've already processed the renewal
@@ -147,7 +148,8 @@ class VindiWebhooks
       'cycle' => $data->bill->period->cycle,
       'bill_status' => $data->bill->status,
       'bill_id' => $data->bill->id,
-      'bill_print_url' => $data->bill->charges[0]->print_url
+      'bill_print_url' => $data->bill->charges[0]->print_url,
+      'bill_due_at' => $data->bill->due_at
     ];
 
     if (!$this->subscription_has_order_in_cycle(


### PR DESCRIPTION
## O que mudou
Clientes que possuírem a extensão "WooCommerce Memberships", terão os pedidos alterados para "Pendente de cancelamento" ao invés de "Aguardando".
Isso ocorre, pois o status "Aguardando" bloqueia as funcionalidades concedidas pelo plugin até que o pagamento seja realizado. Já o status "Pendente de cancelamento" matem as funcionalidades ativas durante o período de pendência  de pagamento.
Após a confirmação de pagamento, foi adicionada uma rotina que atualiza a assinatura para ativa.

## Motivação
Clientes que utilizam a extensão "WooCommerce Memberships" tem o acesso de sua assinatura interrompida durante as renovações até que haja compensação do pagamento.
O ideal é que o acesso somente seja interrompido caso não haja pagamento durante o vencimento estipulado.

## Solução proposta
Ajustar o status padrão que será alterado o pedido durante as renovações de assinaturas que possuam o vínculo com o Memberships.