### PR TITLE
Insere ajuste no período de assinaturas criadas via Boleto

### DIFF
--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -509,5 +509,20 @@ class VindiRoutes
 
         return true;
     }
+
+    public function updatePeriod($period_id, $data)
+    {
+
+      $response = $this->api->request(sprintf(
+        'periods/%s',
+        filter_var($period_id, FILTER_SANITIZE_NUMBER_INT)
+      ), 'PUT', $data);
+
+      if (isset($response['period'])) {
+        return $response['period'];
+      }
+
+      return false;
+    }
 }
 ?>


### PR DESCRIPTION
## O que mudou
Caso o método de pagamento seja Boleto bancário, o tempo de compensação do boleto será acrecido na duração do primeiro período. Evitando que o cliente tenha seu tempo de acesso prejudicado por conta do método de pagamento escolhido.

## Motivação
Em clientes que utilizam o plugin "WooCommerce Memberships" (para controle de acesso), as assinaturas criadas via Boleto ficam pendentes até que o pagamento concluído. No entanto, a data de início levada em consideração é a data de criação da assinatura. Isso faz com que o cliente perca o tempo que foi necessário para compensação do pagamento.

## Solução proposta
Ajustar o comportamento ao receber "_Webhooks_" de faturas do primeiro ciclo de uma assinatura, com o status de pagas, e pagamento efetuado através do método de pagamento **Boleto bancário**. Para que a duração do primeiro ciclo seja acrescida da data atual (data de compensação do pagamento) + tempo de duração definido no plano da assinatura.