### PR TITLE
v1.1.12.2 c

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Vindi WooCommerce 2 ===
 Contributors: laertejr, rodasistemas, cleberbonifacio
-Plugin Name: Vindi WooCommerce 2 CUSTOM v5
+Plugin Name: Vindi WooCommerce 2 CUSTOM v6
 Plugin URI: https://github.com/vindi/vindi-woocommerce
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions, vindi-woocommerce, vindi-payment-gateway
@@ -11,7 +11,7 @@ Tested up to: 6.0
 WC requires at least: 3.0.0
 WC tested up to: 6.5.1
 Requires PHP: 5.6
-Stable Tag: 1.1.12.1 c
+Stable Tag: 1.1.12.2 c
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,7 +39,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
-= 1.1.12.1 c - 27/08/2022 =
+= 1.1.12.2 c - 27/08/2022 =
 -Lançamento da versão de patch.
 - **Correção**: Foi desabilitada a renovação automática de pedidos através do WooCommerce Subscriptions, e a gestão de renovação passa a ser exclusiva do plugin Vindi.
 

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -126,8 +126,7 @@ class VindiWebhooks
         'para evitar bloqueios de acesso em clientes relacionados ao plugin WooCommerce Memberships'
       );
 
-      $end_date = date('Y-m-d H:i:s', strtotime($renew_infos['bill_due_at'] . ' + 4 days'));
-      $subscription->update_dates(array('end_date' => $end_date));
+      $subscription->update_dates(array('end_date' => $this->format_date($renew_infos['bill_due_at'])));
     }
 
     // We've already processed the renewal

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -118,7 +118,8 @@ class VindiWebhooks
     update_post_meta($order->id, 'vindi_order', $order_post_meta);
     $this->vindi_settings->logger->log('Novo Período criado: Pedido #'.$order->id);
 
-    if ($this->vindi_settings->dependencies->is_wc_memberships_active()) {
+    if ($this->vindi_settings->dependencies->is_wc_memberships_active()
+      && !$subscription->has_status('pending-cancel')) {
       $subscription->update_status(
         'pending-cancel',
         'O status da assinatura foi atualizado pela Vindi ' .

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.12.1 c');
+define('VINDI_VERSION', '1.1.12.2 c');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Plugin Name: Vindi WooCommerce 2 CUSTOM v5
+ * Plugin Name: Vindi WooCommerce 2 CUSTOM v6
  * Plugin URI: https://github.com/vindi/vindi-woocommerce
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.12.1 c
+ * Version: 1.1.12.2 c
  * Requires at least: 4.4
  * Tested up to: 6.0
  * WC requires at least: 3.0.0


### PR DESCRIPTION
- Foi adicionada uma contingência para hooks simultâneos não interferirem no fluxo de renovação de assinaturas
- Foi removido o prazo de 4 dias após o vencimento antes de fazer o cancelamento.